### PR TITLE
Fix json exception on auth

### DIFF
--- a/src/Accessh.Daemon/Services/DaemonService.cs
+++ b/src/Accessh.Daemon/Services/DaemonService.cs
@@ -114,7 +114,7 @@ namespace Accessh.Daemon.Services
                 Log.Information("Authentication failed");
                 Log.Debug(e.Message);
 
-                if (e is HttpRequestException)
+                if (e is HttpRequestException || e is JsonException)
                 {
                     throw;
                 }


### PR DESCRIPTION
If the API doesn't respond, the proxy returns a 407 error with a null content.
In case of deserialization, an exception occurs. 