### PR TITLE
Fix/failed job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true /p
 FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine-amd64
 WORKDIR /app
 COPY --from=build /app .
+RUN touch /app/authorized_keys
 ENTRYPOINT ["dotnet","Accessh.Daemon.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet restore Accessh.Daemon/Accessh.Daemon.csproj -r linux-musl-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true /p:PublishTrimmed=false /p:PublishReadyToRun=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine-amd64


### PR DESCRIPTION
The daemon is unable to synchronize the keys. 
**Cause :** When the daemon is trimmed, some background jobs are unable to execute correctly.
**Exception :**
> [18:08:15 ERR] Failed to process the job '4355d548-8bcc-453a-a0e2-97e22e1e4301': an exception occurred.
System.IO.FileNotFoundException: Could not load file or assembly 'mscorlib, Culture=neutral, PublicKeyToken=b77a5c561934e089'. The system cannot find the file specified.
 File name: 'mscorlib, Culture=neutral, PublicKeyToken=b77a5c561934e089'
   at System.Reflection.RuntimeAssembly.InternalLoad(ObjectHandleOnStack assemblyName, ObjectHandleOnStack requestingAssembly, StackCrawlMarkHandle stackMark, Boolean throwOnFileNotFound, ObjectHandleOnStack assemblyLoadContext, ObjectHandleOnStack retAssembly)
   at System.Reflection.RuntimeAssembly.InternalLoad(AssemblyName assemblyName, RuntimeAssembly requestingAssembly, StackCrawlMark& stackMark, Boolean throwOnFileNotFound, AssemblyLoadContext assemblyLoadContext)
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef)
   at Hangfire.Common.TypeHelper.AssemblyResolver(String assemblyString)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at System.TypeNameParser.ResolveAssembly(String asmName, Func`2 assemblyResolver, Boolean throwOnError, StackCrawlMark& stackMark)
   at System.TypeNameParser.ConstructType(Func`2 assemblyResolver, Func`4 typeResolver, Boolean throwOnError, Boolean ignoreCase, StackCrawlMark& stackMark)
   at System.TypeNameParser.GetType(String typeName, Func`2 assemblyResolver, Func`4 typeResolver, Boolean throwOnError, Boolean ignoreCase, StackCrawlMark& stackMark)
   at System.Type.GetType(String typeName, Func`2 assemblyResolver, Func`4 typeResolver, Boolean throwOnError)
   at Hangfire.Common.TypeHelper.DefaultTypeResolver(String typeName)
   at System.Linq.Enumerable.SelectArrayIterator`2.ToArray()
   at Hangfire.Storage.InvocationData.DeserializeJob()