### PR TITLE
Feat/docker build size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained false /p:PublishTrimmed=false /p:PublishReadyToRun=true
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine-amd64
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-alpine3.13-amd64
 WORKDIR /app
 COPY --from=build /app .
 RUN touch /app/authorized_keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet restore Accessh.Daemon/Accessh.Daemon.csproj -r linux-musl-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true /p:PublishTrimmed=false /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained false /p:PublishTrimmed=false /p:PublishReadyToRun=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine-amd64


### PR DESCRIPTION
Disable self contained app + switch to asp core runtime.

Image size decrease :
-> ~202MB to ~110MB (-54%)