### PR TITLE
Fix deadlock dispose

### DIFF
--- a/src/Accessh.Configuration/Interfaces/IClientService.cs
+++ b/src/Accessh.Configuration/Interfaces/IClientService.cs
@@ -6,7 +6,7 @@ namespace Accessh.Configuration.Interfaces
     {
         string Jwt { set; }
         Task Connect();
-        Task Dispose();
+        void Dispose();
         void InitRoute();
         void AskGetKeys();
     }

--- a/src/Accessh.Daemon/Services/DaemonService.cs
+++ b/src/Accessh.Daemon/Services/DaemonService.cs
@@ -167,7 +167,7 @@ namespace Accessh.Daemon.Services
             try
             {
                 await _fileService.RemoveAll();
-                await _clientService.Dispose();
+                _clientService.Dispose();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
In some cases, the daemon is blocked when it wants to renew the connection.

The "dispose" function caused a deadlock. Now, even if the hub connection object is not closed within 10 seconds, the daemon continues the reconnection scheme.