### PR TITLE
Fix/reconnect failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v1.0.3
+
+### Bug Fixes
+
+- If the connection failed, the daemon did not make a new attempt. Now, the connection error is correctly reported, and the daemon will continue its attempts.
+
 ## v1.0.2
 
 ### Enhancement

--- a/build/deb/DEBIAN/control
+++ b/build/deb/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: sh-daemon
-Version: 1.0.2
+Version: 1.0.3
 Section: custom
 Priority: optional
 Architecture: all

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-daemon_version=1.0.2
+daemon_version=1.0.3
 sudo_cmd=''
 restart_cmd="$sudo_cmd systemctl restart sh-daemon"
 config_location=/etc/sh-daemon/config.json

--- a/releasesnotes/NOTES.md
+++ b/releasesnotes/NOTES.md
@@ -1,8 +1,3 @@
-### Enhancement
+### Bug Fixes
 
-- The daemon tries to reconnect immediately after a connection loss instead of waiting for a minute
-
-### Other Notes
-
-- Update log messages
-- Update api url (Auth & Hub)
+- If the connection failed, the daemon did not make a new attempt. Now, the connection error is correctly reported, and the daemon will continue its attempts.

--- a/src/Accessh.Daemon/Services/DaemonService.cs
+++ b/src/Accessh.Daemon/Services/DaemonService.cs
@@ -96,7 +96,7 @@ namespace Accessh.Daemon.Services
                 {
                     var errorResponse = await JsonSerializer.DeserializeAsync
                         <Response<string[]>>(await response.Content.ReadAsStreamAsync(), serializerOption);
-                    
+
                     if (errorResponse != null)
                     {
                         ShowErrors(errorResponse.Errors);
@@ -120,7 +120,7 @@ namespace Accessh.Daemon.Services
                 Log.Information("Daemon: Authentication failed");
                 Log.Debug("Daemon: {Name}", e.GetType().Name);
                 Log.Debug("Daemon: {Message}", e.Message);
-                
+
                 if (e is HttpRequestException or JsonException ||
                     e is TaskCanceledException && e.InnerException is TimeoutException)
                 {
@@ -156,13 +156,12 @@ namespace Accessh.Daemon.Services
                 if (e is WebSocketException)
                 {
                     Log.Warning("Daemon: Connection failed ... Next attempt soon");
+                    throw;
                 }
-                else
-                {
-                    Log.Fatal("Daemon: A critical error has occurred");
-                    Log.Warning("Daemon: {Message}", e.Message);
-                    _cancellationToken.Cancel();
-                }
+
+                Log.Fatal("Daemon: A critical error has occurred");
+                Log.Warning("Daemon: {Message}", e.Message);
+                _cancellationToken.Cancel();
             }
         }
 

--- a/src/Accessh.Daemon/appsettings.Docker.json
+++ b/src/Accessh.Daemon/appsettings.Docker.json
@@ -1,5 +1,5 @@
 {
-  "Version": "1.0.2",
+  "Version": "1.0.3",
   "HubUrl": "https://api.acces.sh/v1/Hub/Server",
   "ServerUrl": "https://api.acces.sh/v1/",
   "ConfigurationFilePath": "",

--- a/src/Accessh.Daemon/appsettings.json
+++ b/src/Accessh.Daemon/appsettings.json
@@ -1,7 +1,7 @@
 {
+  "Version": "1.0.3",
   "HubUrl": "https://api.acces.sh/v1/Hub/Server",
   "ServerUrl": "https://api.acces.sh/v1/",
-  "Version": "1.0.3",
   "ConfigurationFilePath": "/etc/sh-daemon/",
   "Mode": 0,
   "Serilog": {

--- a/src/Accessh.Daemon/appsettings.json
+++ b/src/Accessh.Daemon/appsettings.json
@@ -1,7 +1,7 @@
 {
-  "Version": "1.0.2",
   "HubUrl": "https://api.acces.sh/v1/Hub/Server",
   "ServerUrl": "https://api.acces.sh/v1/",
+  "Version": "1.0.3",
   "ConfigurationFilePath": "/etc/sh-daemon/",
   "Mode": 0,
   "Serilog": {


### PR DESCRIPTION
If the connection to the api failed, the error was not reported, and the connection job could not be restarted.